### PR TITLE
Fix button creation logic

### DIFF
--- a/Stockpiler.py
+++ b/Stockpiler.py
@@ -1351,16 +1351,13 @@ def CreateButtons(self):
 		folder = "CheckImages//Default//"
 	else:
 		folder = "CheckImages//Modded//"
-	for i in range(len(items.data)+1):
-		for x in items.data:
-			if x[0] == str(i):
-				if os.path.exists(folder + str(i) + ".png") or os.path.exists(folder + str(i) + "C.png"):
-					try:
-						menu.icons.append((i, folder + str(i) + ".png", int(x[9]), int(x[10]), int(x[19]), str(x[3]), str(x[8])))
-					except Exception as e:
-						print("Exception: ", e)
-						print(x[17])
-						print("oops", i)
+	for x in items.data:
+			if os.path.exists(folder + x[0] + ".png") or os.path.exists(folder + x[0] + "C.png"):
+				try:
+					menu.icons.append((x[0], folder + x[0] + ".png", int(x[9]), int(x[10]), int(x[19]), str(x[3]), str(x[8])))
+				except Exception as e:
+					print("Exception: ", e)
+					print(x[17])
 	sortedicons = sorted(menu.icons, key=lambda x: (x[2], x[3]))
 
 	SettingsFrame.columnconfigure(0, weight=1)


### PR DESCRIPTION
Button creation logic was able to be simplified. Previously there was a precondition in which an Item's ID and its row in the ItemNumbering.csv needed to be equal as the row index value was used to "find" the icon's file name.

The item's ID should be equal to the row index anyway. So we're removing the outer loop and relying on the Item ID.

This also fixes an issue with adding new items.